### PR TITLE
iOS fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ module.exports = input => {
 
 	document.body.appendChild(el);
 	el.select();
+	el.selectionStart = 0;
+	el.selectionEnd = input.length;
 
 	let success = false;
 	try {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ module.exports = input => {
 
 	document.body.appendChild(el);
 	el.select();
+
+	// Explicit selection workaround for iOS
 	el.selectionStart = 0;
 	el.selectionEnd = input.length;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copy-text-to-clipboard",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Copy text to the clipboard in modern browsers (0.2 kB)",
   "license": "MIT",
   "repository": "sindresorhus/copy-text-to-clipboard",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copy-text-to-clipboard",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Copy text to the clipboard in modern browsers (0.2 kB)",
   "license": "MIT",
   "repository": "sindresorhus/copy-text-to-clipboard",


### PR DESCRIPTION
iOS devices (of the ones I was able to test) were unable to successfully copy any unicorns to their clipboard.

Visiting the [current demo code](https://jsfiddle.net/sindresorhus/6406v3pf) with an iOS ~v10.3 device should show the unintended behavior.

After reviewing the project Cheval I found they resolved this issue [by applying a selectionStart and selectionEnd to the appended textarea](https://github.com/ryanpcmcquen/cheval/blob/gh-pages/cheval.js#L140) so iOS devices would be able to copy the expected number of unicorns.  Please see [my example codepen with the proposed update](https://codepen.io/_mattjensen/pen/KvqomK) for a reference.