### PR TITLE
Modified to use regular function, support IE

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const copyTextToClipboard = input => {
+const copyTextToClipboard = function (input) {
 	const element = document.createElement('textarea');
 	const previouslyFocusedElement = document.activeElement;
 


### PR DESCRIPTION
If this module is added to a project supporting IE browsers, depending on how transpilation is done you can end up using code with fat arrows in it. Which is not supported on IE11 browsers (https://caniuse.com/#feat=arrow-functions)

Changing for a regular function expression works the same. 