### PR TITLE
Add `target` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,12 +3,10 @@
 declare namespace copyTextToClipboard {
 	interface Options {
 		/**
-		Allow overriding the append target, for instance to stay within modal focus traps.
-
-		Note: Only specify this when there’s a known need for it.
+		Specify a DOM element where the temporary, behind-the-scenes `textarea` should be appended, in cases where you need to stay within a focus trap, like in a modal.
 
 		@default document.body
-		
+
 		@example
 		```
 		import copy = require('copy-text-to-clipboard');

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference lib="dom" />
+/// <reference lib="dom"/>
 
 declare namespace copyTextToClipboard {
 	interface Options {
@@ -7,7 +7,20 @@ declare namespace copyTextToClipboard {
 
 		Note: Only specify this when there’s a known need for it.
 
-		@default: Document.body
+		@default document.body
+		
+		@example
+		```
+		import copy = require('copy-text-to-clipboard');
+
+		const modalWithFocusTrap = document.getElementById('modal');
+
+		button.addEventListener('click', () => {
+			copy('🦄🌈', {
+				target: modalWithFocusTrap
+			});
+		});
+		```
 		*/
 		target?: HTMLElement;
 	}
@@ -28,18 +41,6 @@ declare const copyTextToClipboard: {
 
 	button.addEventListener('click', () => {
 		copy('🦄🌈');
-	});
-	```
-
-	@example
-	```
-	import copy = require('copy-text-to-clipboard');
-	const modalWithFocusTrap = document.getElementById('modal');
-
-	button.addEventListener('click', () => {
-		copy('🦄🌈', {
-			target: modalWithFocusTrap
-		});
 	});
 	```
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,18 @@
+/// <reference lib="dom" />
+
+declare namespace copyTextToClipboard {
+	interface Options {
+		/**
+		Allow overriding the append target, for instance to stay within modal focus traps.
+
+		Note: Only specify this when there’s a known need for it.
+
+		@default: Document.body
+		*/
+		target?: HTMLElement;
+	}
+}
+
 declare const copyTextToClipboard: {
 	/**
 	Copy text to the clipboard.
@@ -15,8 +30,20 @@ declare const copyTextToClipboard: {
 		copy('🦄🌈');
 	});
 	```
+
+	@example
+	```
+	import copy = require('copy-text-to-clipboard');
+	const modalWithFocusTrap = document.getElementById('modal');
+
+	button.addEventListener('click', () => {
+		copy('🦄🌈', {
+			target: modalWithFocusTrap
+		});
+	});
+	```
 	*/
-	(text: string): boolean;
+	(text: string, options?: copyTextToClipboard.Options): boolean;
 
 	// TODO: Remove this for the next major release, refactor the whole definition to:
 	// declare function copyTextToClipboard(text: string): boolean;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const copyTextToClipboard = input => {
+const copyTextToClipboard = (input, target = document.body) => {
 	const element = document.createElement('textarea');
 	const previouslyFocusedElement = document.activeElement;
 
@@ -20,7 +20,7 @@ const copyTextToClipboard = input => {
 		originalRange = selection.getRangeAt(0);
 	}
 
-	document.body.append(element);
+	target.append(element);
 	element.select();
 
 	// Explicit selection workaround for iOS

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const copyTextToClipboard = (input, target = document.body) => {
+const copyTextToClipboard = (input, { target = document.body } = {}) => {
 	const element = document.createElement('textarea');
 	const previouslyFocusedElement = document.activeElement;
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const copyTextToClipboard = (input, { target = document.body } = {}) => {
+const copyTextToClipboard = (input, {target = document.body} = {}) => {
 	const element = document.createElement('textarea');
 	const previouslyFocusedElement = document.activeElement;
 

--- a/readme.md
+++ b/readme.md
@@ -39,9 +39,16 @@ Returns a `boolean` of whether it succeeded to copy the text.
 
 Must be called in response to a user gesture event, like `click` or `keyup`.
 
-### Options
+#### options
 
-- `target`: Optionally specify a DOM element (`document.body` by default) where the temporary, behind-the-scenes `textarea` should be appended. Specify this in cases where you need to stay within a focus trap, like in a modal.
+Type: `object`
+
+##### target
+
+Type: `HTMLElement`\
+Default: `document.body`
+
+Optionally specify a DOM element where the temporary, behind-the-scenes `textarea` should be appended. Specify this in cases where you need to stay within a focus trap, like in a modal.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -31,9 +31,11 @@ button.addEventListener('click', () => {
 
 ## API
 
-### copy(text)
+### copy(text [, target])
 
 Copy `text` to the clipboard.
+
+Optionally specify a `target` DOM element (`document.body` by default) where the temporary, behind-the-scenes `textarea` should be appended. Use in cases where you need to stay within a focus trap for instance.
 
 Returns a `boolean` of whether it succeeded to copy the text.
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Type: `object`
 Type: `HTMLElement`\
 Default: `document.body`
 
-Optionally specify a DOM element where the temporary, behind-the-scenes `textarea` should be appended. Specify this in cases where you need to stay within a focus trap, like in a modal.
+Specify a DOM element where the temporary, behind-the-scenes `textarea` should be appended, in cases where you need to stay within a focus trap, like in a modal.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ button.addEventListener('click', () => {
 
 ## API
 
-### copy(text [, target])
+### copy(text, target?)
 
 Copy `text` to the clipboard.
 

--- a/readme.md
+++ b/readme.md
@@ -31,16 +31,17 @@ button.addEventListener('click', () => {
 
 ## API
 
-### copy(text, target?)
+### copy(text, options?)
 
 Copy `text` to the clipboard.
-
-Optionally specify a `target` DOM element (`document.body` by default) where the temporary, behind-the-scenes `textarea` should be appended. Use in cases where you need to stay within a focus trap for instance.
 
 Returns a `boolean` of whether it succeeded to copy the text.
 
 Must be called in response to a user gesture event, like `click` or `keyup`.
 
+### Options
+
+- `target`: Optionally specify a DOM element (`document.body` by default) where the temporary, behind-the-scenes `textarea` should be appended. Specify this in cases where you need to stay within a focus trap, like in a modal.
 
 ## Related
 


### PR DESCRIPTION
Motivation: Focus traps (in for instance modals) might break `copy-text-to-clipboard` as `document.body` is outside its ‘area of operation’. By allowing the consumer to specify an append target within the focus trap, this would no longer be an issue.