### PR TITLE
Specify main in package.json for Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "copy-text-to-clipboard",
 	"version": "2.2.0",
 	"description": "Copy text to the clipboard in modern browsers (0.2 kB)",
+	"main": "index.js",
 	"license": "MIT",
 	"repository": "sindresorhus/copy-text-to-clipboard",
 	"funding": "https://github.com/sponsors/sindresorhus",


### PR DESCRIPTION
Hey @sindresorhus,

I was trying to use this package with a [Vite project](https://github.com/afzalsayed96/icones/tree/vscode), however it required one small change to get it to work. 

I was wondering if you'd consider merging this in so we could directly use the package from npm and also to help others who might run into this issue.

Cheers