### PR TITLE
Add missing options to type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,4 +39,4 @@ button.addEventListener('click', () => {
 });
 ```
 */
-export default function copyTextToClipboard(text: string): boolean;
+export default function copyTextToClipboard(text: string, options?: Options): boolean;


### PR DESCRIPTION
It seems that the argument in typings was accidentally removed in v3.