### PR TITLE
fix:ie browser got error if don't have '()'

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ export default function copyTextToClipboard(input, {target = document.body} = {}
 	let isSuccess = false;
 	try {
 		isSuccess = document.execCommand('copy');
-	} catch {}
+	} catch (e) {}
 
 	element.remove();
 


### PR DESCRIPTION
i got an error when  use this plugins on ie, then i add '()' and it fixed