### PR TITLE
Fix syntax error on older browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ export default function copyTextToClipboard(input, {target = document.body} = {}
 	let isSuccess = false;
 	try {
 		isSuccess = document.execCommand('copy');
-	} catch {}
+	} catch (ignore) {}
 
 	element.remove();
 


### PR DESCRIPTION
The follow error happens on some browser, like iOS Safari < 11.3
> Unexpected token '{'. Expected '(' to start a 'catch' target.